### PR TITLE
Fixes:

### DIFF
--- a/Assets/IceCreamModule.cs
+++ b/Assets/IceCreamModule.cs
@@ -36,6 +36,7 @@ public class IceCreamModule : MonoBehaviour
     private int _moduleID;
     private static int _moduleIDCounter = 1;
     private bool _isSolved;
+    private bool _isActivated;
 
     // Mod Settings (opening times)
     class Settings
@@ -137,6 +138,9 @@ public class IceCreamModule : MonoBehaviour
     {
         _moduleID = _moduleIDCounter++;
 
+        CustomerLabel.text = "";
+        FlavourLabel.text = "ICE CREAM";
+
         ModSettings.RefreshSettings();
         modSettings = JsonConvert.DeserializeObject<Settings>(ModSettings.Settings);
 
@@ -174,6 +178,7 @@ public class IceCreamModule : MonoBehaviour
 
     void OnActivate()
     {
+        _isActivated = true;
         // Conditional tally lookup.
         foreach (object[] plate in BombInfo.GetPortPlates())
         {
@@ -294,7 +299,8 @@ public class IceCreamModule : MonoBehaviour
     void HandlePress(int button)
     {
         Audio.PlaySoundAtTransform("tick", transform);
-
+        if (!_isActivated)
+            return;
         switch (button)
         {
             case -1:

--- a/Assets/Models/Materials.meta
+++ b/Assets/Models/Materials.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 979cefd953a42fa4b8d7144b5547d0a4
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Models/Materials/Component_Keypad_Background.mat
+++ b/Assets/Models/Materials/Component_Keypad_Background.mat
@@ -1,0 +1,76 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!21 &2100000
+Material:
+  serializedVersion: 6
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_Name: Component_Keypad_Background
+  m_Shader: {fileID: 46, guid: 0000000000000000f000000000000000, type: 0}
+  m_ShaderKeywords: 
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
+  disabledShaderPasses: []
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _BumpMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailAlbedoMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailMask:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailNormalMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _EmissionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MainTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MetallicGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _OcclusionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _ParallaxMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Floats:
+    - _BumpScale: 1
+    - _Cutoff: 0.5
+    - _DetailNormalMapScale: 1
+    - _DstBlend: 0
+    - _GlossMapScale: 1
+    - _Glossiness: 0
+    - _GlossyReflections: 1
+    - _Metallic: 0
+    - _Mode: 0
+    - _OcclusionStrength: 1
+    - _Parallax: 0.02
+    - _SmoothnessTextureChannel: 0
+    - _SpecularHighlights: 1
+    - _SrcBlend: 1
+    - _UVSec: 0
+    - _ZWrite: 1
+    m_Colors:
+    - _Color: {r: 1, g: 1, b: 1, a: 1}
+    - _EmissionColor: {r: 0, g: 0, b: 0, a: 0}

--- a/Assets/Models/Materials/Component_Keypad_Background.mat.meta
+++ b/Assets/Models/Materials/Component_Keypad_Background.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 0369acdbe16449f4a9ad3166ea9104e0
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Models/Materials/Component_Keypad_LED_OFF.mat
+++ b/Assets/Models/Materials/Component_Keypad_LED_OFF.mat
@@ -1,0 +1,76 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!21 &2100000
+Material:
+  serializedVersion: 6
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_Name: Component_Keypad_LED_OFF
+  m_Shader: {fileID: 46, guid: 0000000000000000f000000000000000, type: 0}
+  m_ShaderKeywords: 
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
+  disabledShaderPasses: []
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _BumpMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailAlbedoMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailMask:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailNormalMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _EmissionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MainTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MetallicGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _OcclusionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _ParallaxMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Floats:
+    - _BumpScale: 1
+    - _Cutoff: 0.5
+    - _DetailNormalMapScale: 1
+    - _DstBlend: 0
+    - _GlossMapScale: 1
+    - _Glossiness: 0
+    - _GlossyReflections: 1
+    - _Metallic: 0
+    - _Mode: 0
+    - _OcclusionStrength: 1
+    - _Parallax: 0.02
+    - _SmoothnessTextureChannel: 0
+    - _SpecularHighlights: 1
+    - _SrcBlend: 1
+    - _UVSec: 0
+    - _ZWrite: 1
+    m_Colors:
+    - _Color: {r: 1, g: 1, b: 1, a: 1}
+    - _EmissionColor: {r: 0, g: 0, b: 0, a: 0}

--- a/Assets/Models/Materials/Component_Keypad_LED_OFF.mat.meta
+++ b/Assets/Models/Materials/Component_Keypad_LED_OFF.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: aaf59be7051db5e44a5937e0886a069e
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/TestHarness/TestHarness.cs
+++ b/Assets/TestHarness/TestHarness.cs
@@ -9,7 +9,7 @@ using Random = UnityEngine.Random;
 
 public class FakeBombInfo : MonoBehaviour
 {
-    float startupTime = .5f;
+    float startupTime = 3f;
 
     public KMAudio Audio;
 


### PR DESCRIPTION
- Prevent exceptions caused by pressing buttons before bomb is activated.
- Change display to say "ICE CREAM" before activation (instead of default name/flavor from the Unity prefab)